### PR TITLE
fix: 🐛 typo in MinMaxScaler

### DIFF
--- a/basicts/scaler/min_max_scaler.py
+++ b/basicts/scaler/min_max_scaler.py
@@ -52,8 +52,8 @@ class MinMaxScaler(BaseScaler):
 
         # compute minimum and maximum values for normalization
         if norm_each_channel:
-            self.min = torch.tensor(np.min(train_data, axis=0, keepdims=True))
-            self.max = torch.tensor(np.max(train_data, axis=0, keepdims=True))
+            self.min = np.min(train_data, axis=0, keepdims=True)
+            self.max = np.max(train_data, axis=0, keepdims=True)
         else:
             self.min = np.min(train_data)
             self.max = np.max(train_data)


### PR DESCRIPTION
Repeatedly construct tensor self.min/self.max in MinMaxScaler.

`<stdin>:1: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).`