### PR TITLE
Lightning backend 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ todo.md
 gpu_task.py
 cmd.sh
 
+
 # file
 *.npz
 *.npy
@@ -19,6 +20,7 @@ cmd.sh
 *.pyc
 *.txt
 *.core
+*.ckpt
 
 *.py[cod]
 *$py.class

--- a/basicts/data/__init__.py
+++ b/basicts/data/__init__.py
@@ -1,4 +1,5 @@
 from .base_dataset import BaseDataset
 from .simple_tsf_dataset import TimeSeriesForecastingDataset
+from .tsf_datamodule import TimeSeriesForecastingModule
 
-__all__ = ['BaseDataset', 'TimeSeriesForecastingDataset']
+__all__ = ['BaseDataset', 'TimeSeriesForecastingDataset', 'TimeSeriesForecastingModule']

--- a/basicts/data/tsf_datamodule.py
+++ b/basicts/data/tsf_datamodule.py
@@ -1,0 +1,107 @@
+from typing import List
+
+from basicts.utils import get_regular_settings
+from .base_dataset import BaseDataset
+import lightning.pytorch as pl
+from importlib import import_module
+from torch.utils.data import DataLoader
+
+
+class TimeSeriesForecastingModule(pl.LightningDataModule):
+    def __init__(
+        self,
+        dataset_class: str,
+        dataset_name: str,
+        train_val_test_ratio: List[float],
+        input_len: int,
+        output_len: int,
+        overlap: bool = False,
+        batch_size: int = 32,
+        num_workers: int = 0,
+        pin_memory: bool = False,
+        shuffle: bool = False,
+        prefetch: bool = False,
+    ):
+        super().__init__()
+        dataset_class_packeg, dataset_class_name = dataset_class.rsplit(".", 1)
+        self.dataset_class = getattr(
+            import_module(dataset_class_packeg), dataset_class_name
+        )
+        if prefetch:
+            # todo: implement DataLoaderX
+            # self.dataloader_class = DataLoaderX
+            raise NotImplementedError("DataLoaderX is not implemented yet.")
+        else:
+            self.dataloader_class = DataLoader
+        self.dataset_name = dataset_name
+        self.train_val_test_ratio = train_val_test_ratio
+        self.input_len = input_len
+        self.output_len = output_len
+        self.overlap = overlap
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.pin_memory = pin_memory
+        self.shuffle = shuffle
+        self.prefetch = prefetch
+        self.regular_settings = get_regular_settings(dataset_name)
+
+
+        # self.train_set = TimeSeriesForecastingDataset()
+
+    @property
+    def dataset_params(self):
+        return {
+            "dataset_name": self.dataset_name,
+            "train_val_test_ratio": self.train_val_test_ratio,
+            "input_len": self.input_len,
+            "output_len": self.output_len,
+            "overlap": self.overlap,
+        }
+
+    def train_dataloader(self):
+        """Build train dataset and dataloader.
+
+        Returns:
+            train data loader (DataLoader)
+        """
+        dataset = self.dataset_class(**self.dataset_params, mode="train")
+        loader = self.dataloader_class(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+        )
+        return loader
+
+    def val_dataloader(self):
+        """Build validation dataset and dataloader.
+
+        Returns:
+            validation data loader (DataLoader)
+        """
+        dataset = self.dataset_class(**self.dataset_params, mode="valid")
+        loader = self.dataloader_class(
+            dataset,
+            batch_size=self.batch_size,
+            # shuffle=self.shuffle,   # No need to shuffle validation data
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+        )
+        return loader
+
+    def test_dataloader(self):
+        """Build test dataset and dataloader.
+
+        Returns:
+            test data loader (DataLoader)
+        """
+        dataset = self.dataset_class(**self.dataset_params, mode="test")
+        loader = self.dataloader_class(
+            dataset,
+            batch_size=self.batch_size,
+            # shuffle=self.shuffle, # No need to shuffle test data
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+        )
+        return loader

--- a/basicts/model.py
+++ b/basicts/model.py
@@ -1,0 +1,277 @@
+from functools import wraps
+import functools
+import inspect
+import sched
+import lightning.pytorch as pl
+from typing import Any, Callable, Dict, Optional, Union, List
+
+import numpy as np
+import torch
+
+from basicts.metrics import ALL_METRICS, masked_mae
+from basicts.scaler import BaseScaler
+
+
+class BasicTimeSeriesForecastingModule(pl.LightningModule):
+    def __init__(
+        self,
+        lr: float,
+        weight_decay: float,
+        history_len: int,
+        horizon_len: int,
+        metrics: Optional[List[str]] = None,
+        forward_features: Optional[List[int]] = None,
+        target_features: Optional[List[int]] = None,
+        target_time_series: Optional[List[int]] = None,
+        scaler: Any = None,
+        null_val: Any = np.nan,
+    ):
+        super().__init__()
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.history_len = history_len
+        self.horizon_len = horizon_len
+        self.forward_features = forward_features
+        self.target_features = target_features
+        self.target_time_series = target_time_series
+        self.scaler = scaler
+        self.null_val = null_val
+
+        self.metric_func_dict = self.init_metrics(metrics)
+        if "loss" not in self.metric_func_dict:
+            if hasattr(self, "loss_func"):
+                self.metric_func_dict["loss"] = self.loss_func
+            else:
+                # self.logger.info('No loss function is provided. Using masked_mae as default.')
+                self.metric_func_dict["loss"] = masked_mae
+
+    def init_metrics(self, metrics: Optional[List[str]]) -> Dict[str, Callable]:
+        if metrics is None:
+            return ALL_METRICS
+        return {name: ALL_METRICS[name] for name in metrics}
+
+    def basicts_forward(self, data: Dict, **kwargs) -> Dict:
+        """
+        The forward function of original runner.
+
+        Performs the forward pass for training, validation, and testing.
+
+        Args:
+            data (Dict): A dictionary containing 'target' (future data) and 'inputs' (history data) (normalized by self.scaler).
+
+        Returns:
+            Dict: A dictionary containing the keys:
+                  - 'inputs': Selected input features.
+                  - 'prediction': Model predictions.
+                  - 'target': Selected target features.
+
+        Raises:
+            AssertionError: If the shape of the model output does not match [B, L, N].
+        """
+
+        data = self.preprocessing(data)
+
+        # Preprocess input data
+        future_data, history_data = data["target"], data["inputs"]
+        # history_data = self.to_running_device(history_data)  # Shape: [B, L, N, C]
+        # future_data = self.to_running_device(future_data)  # Shape: [B, L, N, C]
+        batch_size, length, num_nodes, _ = future_data.shape
+
+        # Select input features
+        history_data = self.select_input_features(history_data)
+        future_data_4_dec = self.select_input_features(future_data)
+
+        train = self.trainer.training
+        # epoch = self.trainer.current_epoch
+        # batch_seen = self.trainer.global_step
+
+        if not train:
+            # For non-training phases, use only temporal features
+            future_data_4_dec[..., 0] = torch.empty_like(future_data_4_dec[..., 0])
+
+        # Forward pass through the model
+        model_return = self(
+            history_data=history_data,
+            future_data=future_data_4_dec,
+            # batch_seen=batch_seen,
+            # epoch=epoch,
+            # train=train,
+        )
+
+        # Parse model return
+        if isinstance(model_return, torch.Tensor):
+            model_return = {"prediction": model_return}
+        if "inputs" not in model_return:
+            model_return["inputs"] = self.select_target_features(history_data)
+        if "target" not in model_return:
+            model_return["target"] = self.select_target_features(future_data)
+
+        # Ensure the output shape is correct
+        assert list(model_return["prediction"].shape)[:3] == [
+            batch_size,
+            length,
+            num_nodes,
+        ], "The shape of the output is incorrect. Ensure it matches [B, L, N, C]."
+
+        model_return = self.postprocessing(model_return)
+
+        return model_return
+
+    def metric_forward(self, metric_func, args: Dict) -> torch.Tensor:
+        """Compute metrics using the given metric function.
+
+        Args:
+            metric_func (function or functools.partial): Metric function.
+            args (Dict): Arguments for metrics computation.
+
+        Returns:
+            torch.Tensor: Computed metric value.
+        """
+
+        covariate_names = inspect.signature(metric_func).parameters.keys()
+        args = {k: v for k, v in args.items() if k in covariate_names}
+
+        if isinstance(metric_func, functools.partial):
+            if 'null_val' not in metric_func.keywords and 'null_val' in covariate_names: # null_val is required but not provided
+                args['null_val'] = self.null_val
+            metric_item = metric_func(**args)
+        elif callable(metric_func):
+            if 'null_val' in covariate_names: # null_val is required
+                args['null_val'] = self.null_val
+            metric_item = metric_func(**args)
+        else:
+            raise TypeError(f'Unknown metric type: {type(metric_func)}')
+        return metric_item
+    
+    
+    def training_step(self, batch, batch_idx):
+        forward_return = self.basicts_forward(batch)
+        metrics = {}
+        for metric_name, metric_func in self.metric_func_dict.items():
+            metric_item = self.metric_forward(metric_func, forward_return)
+            metrics[f"train/{metric_name}"] = metric_item
+        self.log_dict(metrics, on_step=True)
+        return metrics["train/loss"]
+
+    def validation_step(self, batch, batch_idx):
+        forward_return = self.basicts_forward(batch)
+        metrics = {}
+        for metric_name, metric_func in self.metric_func_dict.items():
+            metric_item = self.metric_forward(metric_func, forward_return)
+            metrics[f"val/{metric_name}"] = metric_item
+        self.log_dict(metrics, on_step=False, on_epoch=True)
+        return metrics["val/loss"]
+
+    def test_step(self, batch, batch_idx):
+        forward_return = self.basicts_forward(batch)
+        metrics = {}
+        for metric_name, metric_func in self.metric_func_dict.items():
+            metric_item = self.metric_forward(metric_func, forward_return)
+            metrics[f"test/{metric_name}"] = metric_item
+        self.log_dict(metrics, on_step=False, on_epoch=True)
+        return metrics["test/loss"]
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.Adam(
+            self.parameters(), lr=self.lr, weight_decay=self.weight_decay
+        )
+        scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=5, gamma=0.9)
+        return [optimizer], [scheduler]
+
+    def preprocessing(self, input_data: Dict, scale_keys=["target", "inputs"]) -> Dict:
+        """Preprocess data.
+
+        Args:
+            input_data (Dict): Dictionary containing data to be processed.
+            scale_keys (Optional[Union[List[str], str]], optional): 'all' means scale all, None means ingore all, it also can be specificated by a list of str. Defaults to None.
+
+        Returns:
+            Dict: Processed data.
+        """
+        if scale_keys is None:
+            scale_keys = []
+        elif scale_keys == "all":
+            scale_keys = input_data.keys()
+
+        if self.scaler is not None:
+            for k in scale_keys:
+                input_data[k] = self.scaler.transform(input_data[k])
+        # TODO: add more preprocessing steps as needed.
+        return input_data
+
+    def postprocessing(
+        self, input_data: Dict, scale_keys=["target", "inputs", "prediction"]
+    ) -> Dict:
+        """Postprocess data.
+
+        Args:
+            input_data (Dict): Dictionary containing data to be processed.
+            scale_keys (Optional[Union[List[str], str]], optional): 'all' means scale all, None means ingore all, it also can be specificated by a list of str. Defaults to None.
+
+        Returns:
+            Dict: Processed data.
+        """
+
+        # rescale data
+        if self.scaler is not None and self.scaler.rescale:
+            if scale_keys is None:
+                scale_keys = []
+            elif scale_keys == "all":
+                scale_keys = input_data.keys()
+            for k in scale_keys:
+                input_data[k] = self.scaler.inverse_transform(input_data[k])
+
+        # subset forecasting
+        if self.target_time_series is not None:
+            input_data["target"] = input_data["target"][
+                :, :, self.target_time_series, :
+            ]
+            input_data["prediction"] = input_data["prediction"][
+                :, :, self.target_time_series, :
+            ]
+
+        # TODO: add more postprocessing steps as needed.
+        return input_data
+
+    def select_input_features(self, data: torch.Tensor) -> torch.Tensor:
+        """
+        Selects input features based on the forward features specified in the configuration.
+
+        Args:
+            data (torch.Tensor): Input history data with shape [B, L, N, C1].
+
+        Returns:
+            torch.Tensor: Data with selected features with shape [B, L, N, C2].
+        """
+
+        if self.forward_features is not None:
+            data = data[:, :, :, self.forward_features]
+        return data
+
+    def select_target_features(self, data: torch.Tensor) -> torch.Tensor:
+        """
+        Selects target features based on the target features specified in the configuration.
+
+        Args:
+            data (torch.Tensor): Model prediction data with shape [B, L, N, C1].
+
+        Returns:
+            torch.Tensor: Data with selected target features and shape [B, L, N, C2].
+        """
+
+        data = data[:, :, :, self.target_features]
+        return data
+
+    def select_target_time_series(self, data: torch.Tensor) -> torch.Tensor:
+        """
+        Select target time series based on the target time series specified in the configuration.
+
+        Args:
+            data (torch.Tensor): Model prediction data with shape [B, L, N1, C].
+
+        Returns:
+            torch.Tensor: Data with selected target time series and shape [B, L, N2, C].
+        """
+
+        data = data[:, :, self.target_time_series, :]
+        return data

--- a/examples/arch.py
+++ b/examples/arch.py
@@ -1,9 +1,15 @@
 # pylint: disable=unused-argument
+from typing import Any, List, Optional
+import numpy as np
 import torch
 from torch import nn
+import lightning.pytorch as pl
+
+from basicts.model import BasicTimeSeriesForecastingModule
+from basicts.scaler import BaseScaler
 
 
-class MultiLayerPerceptron(nn.Module):
+class MultiLayerPerceptron(BasicTimeSeriesForecastingModule):
     """
     A simple Multi-Layer Perceptron (MLP) model with two fully connected layers.
 
@@ -16,7 +22,20 @@ class MultiLayerPerceptron(nn.Module):
         act (nn.ReLU): The ReLU activation function applied between the two layers.
     """
 
-    def __init__(self, history_seq_len: int, prediction_seq_len: int, hidden_dim: int):
+    def __init__(
+        self,
+        lr: float,
+        weight_decay: float,
+        history_len: int,
+        horizon_len: int,
+        hidden_dim: int,
+        metrics: Optional[List[str]] = None,
+        forward_features: Optional[List[int]] = None,
+        target_features: Optional[List[int]] = None,
+        target_time_series: Optional[List[int]] = None,
+        scaler: Any = None,
+        null_val: Any = np.nan,
+    ):
         """
         Initialize the MultiLayerPerceptron model.
 
@@ -24,28 +43,41 @@ class MultiLayerPerceptron(nn.Module):
             history_seq_len (int): The length of the input history sequence.
             prediction_seq_len (int): The length of the output prediction sequence.
             hidden_dim (int): The number of units in the hidden layer.
+
         """
-        super().__init__()
-        self.fc1 = nn.Linear(history_seq_len, hidden_dim)
-        self.fc2 = nn.Linear(hidden_dim, prediction_seq_len)
+        super().__init__(
+            lr=lr,
+            weight_decay=weight_decay,
+            history_len=history_len,
+            horizon_len=horizon_len,
+            metrics=metrics,
+            forward_features=forward_features,
+            target_features=target_features,
+            target_time_series=target_time_series,
+            scaler=scaler,
+            null_val=null_val,
+        )
+        self.fc1 = nn.Linear(history_len, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, horizon_len)
         self.act = nn.ReLU()
 
-    def forward(self, history_data: torch.Tensor, future_data: torch.Tensor, batch_seen: int, epoch: int, train: bool) -> torch.Tensor:
+    def forward(
+        self,
+        history_data: torch.Tensor,
+        future_data: torch.Tensor,
+    ) -> torch.Tensor:
         """
         Perform a forward pass through the network.
 
         Args:
             history_data (torch.Tensor): A tensor containing historical data, typically of shape `[B, L, N, C]`.
             future_data (torch.Tensor): A tensor containing future data, typically of shape `[B, L, N, C]`.
-            batch_seen (int): The number of batches seen so far during training.
-            epoch (int): The current epoch number.
-            train (bool): Flag indicating whether the model is in training mode.
 
         Returns:
             torch.Tensor: The output prediction tensor, typically of shape `[B, L, N, C]`.
         """
 
-        history_data = history_data[..., 0].transpose(1, 2) # [B, L, N, C] -> [B, N, L]
+        history_data = history_data[..., 0].transpose(1, 2)  # [B, L, N, C] -> [B, N, L]
 
         # [B, N, L] --h=act(fc1(x))--> [B, N, D] --fc2(h)--> [B, N, L] -> [B, L, N]
         prediction = self.fc2(self.act(self.fc1(history_data))).transpose(1, 2)

--- a/examples/lightning_config.yaml
+++ b/examples/lightning_config.yaml
@@ -1,0 +1,67 @@
+fit:
+  model: 
+    class_path: examples.arch.MultiLayerPerceptron
+    init_args:
+      lr: 2e-3
+      weight_decay: 1e-4
+      history_len: 12
+      horizon_len: 12
+      hidden_dim: 64
+      forward_features: [0, 1, 2]
+      target_features: [0]
+      metrics: 
+        - MAE
+        - MAPE
+        - RMSE
+      scaler:
+        class_path: basicts.scaler.ZScoreScaler
+        init_args:
+          dataset_name: ${fit.data.init_args.dataset_name}
+          train_ratio: ${fit.data.init_args.train_val_test_ratio[0]}
+          norm_each_channel: False
+          rescale: True
+  data:
+    class_path: basicts.data.TimeSeriesForecastingModule
+    init_args:
+      dataset_class: basicts.data.TimeSeriesForecastingDataset
+      dataset_name: PEMS08
+      train_val_test_ratio: [0.6, 0.2, 0.2]
+      # input_len: 12
+      # output_len: 12
+      # To enable variable interpolation, first install omegaconf (pip install omegaconf)
+      input_len: ${fit.model.init_args.history_len}
+      output_len: ${fit.model.init_args.horizon_len}
+      overlap: False
+  trainer:
+    max_epochs: 10
+    devices: auto
+    log_every_n_steps: 10
+    callbacks:
+      # Use rich for better progress bar and model summary (pip install rich)
+      - class_path: lightning.pytorch.callbacks.RichProgressBar
+      - class_path: lightning.pytorch.callbacks.RichModelSummary
+      - class_path: lightning.pytorch.callbacks.EarlyStopping
+        init_args:
+          monitor: val/loss
+          patience: 10
+          mode: min
+      - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+        init_args:
+          monitor: val/loss
+          mode: min
+          save_top_k: 1
+          dirpath: ${fit.trainer.logger.init_args.save_dir}/${fit.trainer.logger.init_args.name}
+          filename: best
+    logger:
+      class_path: lightning.pytorch.loggers.TensorBoardLogger
+      init_args:
+        save_dir: examples/lightning_logs
+        name: ${fit.data.init_args.dataset_name}
+
+test:
+  data: ${fit.data}
+  model: ${fit.model}
+  trainer: ${fit.trainer}
+  # Specify the checkpoint path to test, it is recommended to speicify in the command line, e.g., --ckpt_path=examples/lightning_logs/best.ckpt
+  # ckpt_path: examples/lightning_logs/best.ckpt  
+  

--- a/examples/lightning_config.yaml
+++ b/examples/lightning_config.yaml
@@ -38,8 +38,8 @@ fit:
     log_every_n_steps: 10
     callbacks:
       # Use rich for better progress bar and model summary (pip install rich)
-      - class_path: lightning.pytorch.callbacks.RichProgressBar
-      - class_path: lightning.pytorch.callbacks.RichModelSummary
+      # - class_path: lightning.pytorch.callbacks.RichProgressBar
+      # - class_path: lightning.pytorch.callbacks.RichModelSummary
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
           monitor: val/loss

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-easy-torch
+# easy-torch
 easydict
 packaging
 setproctitle
@@ -7,5 +7,8 @@ scikit-learn
 tables
 sympy
 openpyxl
-setuptools==59.5.0
-numpy==1.24.4
+rich
+lightning[pytorch-extra]
+# omegaconf
+# setuptools==59.5.0
+# numpy==1.24.4

--- a/run.py
+++ b/run.py
@@ -1,0 +1,43 @@
+# Run a baseline model in BasicTS framework.
+# pylint: disable=wrong-import-position
+import os
+import sys
+from pathlib import Path
+
+FILE_PATH = Path(__file__).resolve()
+PROJECT_DIR = FILE_PATH.parent  # PROJECT_DIR
+BASICTS_DIR = PROJECT_DIR / "basicts"  # BASICTS_DIR
+sys.path.append(PROJECT_DIR.as_posix())
+sys.path.append(BASICTS_DIR.as_posix())
+# os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from lightning.pytorch.cli import LightningCLI
+
+from basicts.data.tsf_datamodule import TimeSeriesForecastingModule
+from basicts.model import BasicTimeSeriesForecastingModule
+# from .baselines
+
+
+class BasicTSCLI(LightningCLI):
+    def add_arguments_to_parser(self, parser):
+        super().add_arguments_to_parser(parser)
+
+        # parser.link_arguments("model.init_args.null_val", "data.regular_settings[NULL_VAL]")
+        # parser.link_arguments("model.init_args.history_len", "data.init_args.input_len")
+        # parser.link_arguments("data.init_args.prediction_len", "data.init_args.output_len")
+
+
+def run():
+    cli = BasicTSCLI(
+        run=True,
+        trainer_defaults={},
+        parser_kwargs={"parser_mode": "omegaconf"},  # pip install omegaconf
+        save_config_kwargs={"overwrite": True, "save_to_log_dir": True},
+    )
+    if cli.subcommand in ("fit", "validate") and not cli.trainer.fast_dev_run:
+        # 被动执行了 fit 或者 validate，追加一个 test
+        cli.trainer.test(datamodule=cli.datamodule, ckpt_path="best")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
简单地基于`lightning`重构了框架，适配了原框架的大部分命令和配置。建议作为一个使用lightning替换后端的分支的起点。

### 基本说明

简单运行（训练+校验+测试）：

```sh
python run.py --config=examples/lightning_config.yaml fit
```

仅测试（需要替换`CKPT_PATH`，如`fit`后保存的模型`examples\lightning_logs\PEMS08\best.ckpt`）：

```sh
python run.py --config=examples/lightning_config.yaml test --ckpt_path {CKPT_PATH}
```

查看训练日志

```sh
tensorboard --logdir .\examples\lightning_logs
```

### 主要重构部分

- .gitignore：增加 .ckpt 文件。
- basicts/data/tsf_datamodule.py：使用 `LightningDataModule` 包装数据集和加载器。
- basicts/model.py：主要类依赖和逻辑的重构。在 `LightningModule` 的子类 `BasicTimeSeriesForecastingModule`中实现有关推理（train/validation/step/predict）和数据处理（如 `Scaler`、前/后处理等）的部分功能，**相当于将原框架中 `Runner`和`Model`的组合关系变成 `BasicTimeSeriesForecastingModule`和`Model`的继承关系**，具体的训练过程（如早停、梯度裁剪、ckpt保存等）交由 `lightning.Trainer` 进行控制。
- examples/arch.py：MLP 示例模型，主要修改了 `__init__` 方法、将优化器的定义下放到模型代码中。
- examples/lightning_config.yaml：`lightning` 支持的配置文件示例。
- requirements.txt：增加了 `lightning` 相关依赖。
- run.py：项目通用入口文件，模型/数据集的选择 、超参数的设置全部由具体配置文件、模型代码管理。

### 需要完成的后续工作

- 适配 baseline
- 适配测试代码
- 更新文档
- 移除依赖 `easytorch` 的旧版本框架代码
- 进一步重构框架，使其更加符合 `lightning` 的风格
- 其他的一些测试、适配以及 BUG 修复